### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds the `releaseBranch:` block to `enonic/release-tools/build-and-publish`, listing both `master` and `2.x`. This is the prep work that lets the `2.x` maintenance branch cut XP 7 patch releases independently of XP 8 work on `master`.
- This is the maintenance-branch half of the XP 7 → XP 8 split. The companion master PR upgrades the library to XP 8 (`xpVersion=8.0.0-B4`, `version=3.0.0-SNAPSHOT`).
- `gradle.properties`, `enonic-docgen.yml`, and `docs/versions.json` are intentionally NOT touched on this branch — those are master-only per the app-booster reference pattern. The `2.x` branch must preserve `xpVersion=7.0.0` / `version=2.1.2-SNAPSHOT`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a tag/release pushed against `2.x` correctly triggers `build-and-publish` with the release flag set