### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.guava:guava:33.6.0-jre'
-    implementation 'org.apache.commons:commons-text:1.15.0'
-    implementation 'commons-codec:commons-codec:1.22.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
+    implementation libs.guava
+    implementation libs.commons.text
+    implementation libs.commons.codec
+    testImplementation libs.junit.jupiter
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-core:5.23.0'
+    testImplementation libs.mockito.core
     testImplementation "com.enonic.xp:testing:${xpVersion}"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+commons-codec = "1.22.0"
+commons-text = "1.15.0"
+guava = "33.6.0-jre"
+junit = "6.0.3"
+mockito = "5.23.0"
+
+[libraries]
+commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Summary

Move inline dependency versions into `gradle/libs.versions.toml`.

Conventions adopted:
- Alphabetically sorted `[versions]` and `[libraries]` blocks.
- Hyphen-separated, lowercase keys (`commons-codec`, `junit`, …).
- `xpVersion` left in `gradle.properties` (the toolchain expects it there).
- `testRuntimeOnly 'org.junit.platform:junit-platform-launcher'` left inline — it has no explicit version, so the inventory step skipped it.

Pin-for-pin: no version bumps. `runtimeClasspath` and `testRuntimeClasspath` dependency trees verified identical before and after.

## Catalog

```toml
[versions]
commons-codec = "1.22.0"
commons-text = "1.15.0"
guava = "33.6.0-jre"
junit = "6.0.3"
mockito = "5.23.0"

[libraries]
commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
guava = { module = "com.google.guava:guava", version.ref = "guava" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` green
- [x] `./gradlew dependencies --configuration runtimeClasspath` identical pre/post
- [x] `./gradlew dependencies --configuration testRuntimeClasspath` identical pre/post

🤖 Generated with [Claude Code](https://claude.com/claude-code)