### PR TITLE
Align docs to lib-cors layout #152

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "3.x"
       - "2.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Text Encoding Library
 
+NOTE: Versions 3.x target XP 8+.
+
 
 This library contains utility functions for encoding and decoding binary data as text in Enonic XP.
 
@@ -17,7 +19,7 @@ Add the following dependency to your `build.gradle` file:
 [source,groovy]
 ----
 dependencies {
-    include 'com.enonic.lib:lib-text-encoding:2.1.0'
+    include "com.enonic.lib:lib-text-encoding:${libVersion}"
 }
 ----
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Bring `docs/` in line with the reference layout used by `enonic/lib-cors`.

## Changes

- `docs/index.adoc`
  - Added `NOTE: Versions 3.x target XP 8+.` near the top (mirrors lib-cors, and matches the note the `2.x` branch already carries for XP 7).
  - Replaced the hardcoded `2.1.0` in the install example with `${libVersion}` so the snippet stays current across releases (also how lib-cors documents install).
- `docs/versions.json`
  - `stable` → `3.x` (latest), and the older `2.x` line kept as a secondary entry.
  - Dropped the `next` → `master` entry — matches the two-entry shape lib-cors uses.
- `.github/workflows/enonic-docgen.yml`
  - Added `3.x` to the trigger list so pushes to any branch referenced from `versions.json` (plus `master` itself) rebuild the portal.

## What was NOT removed

I reviewed `docs/index.adoc` end-to-end looking for the usual "added in vX.Y", "since X.Y", "starting from version X" clutter and pre-XP 8 legacy notes — there is none in these docs today. Only two version-flavoured mentions existed:

- The `NOTE:` added by this PR — kept, and current.
- The hardcoded `2.1.0` in the install snippet — replaced with `${libVersion}` (see above).

Follow-up: after this lands, the docs-only changes will be cherry-picked to the stable `3.x` branch in a separate PR. The `2.x` branch is deliberately left alone.

Closes #152