### PR TITLE
Align docs to lib-cors layout (3.x) #152

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - "master"
-      - "2.x"
       - "3.x"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Text Encoding Library
 
+NOTE: Versions 3.x target XP 8+.
+
 
 This library contains utility functions for encoding and decoding binary data as text in Enonic XP.
 
@@ -17,7 +19,7 @@ Add the following dependency to your `build.gradle` file:
 [source,groovy]
 ----
 dependencies {
-    include 'com.enonic.lib:lib-text-encoding:2.1.0'
+    include "com.enonic.lib:lib-text-encoding:${libVersion}"
 }
 ----
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "2.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x", "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Cherry-pick of #153 onto the `3.x` stable branch.

Same changes as the master PR — see #153 for the full write-up. In short:

- `docs/index.adoc`: add `NOTE: Versions 3.x target XP 8+.`; drop hardcoded `2.1.0` in install snippet in favour of `${libVersion}`.
- `docs/versions.json`: `stable` → `3.x`, drop `next`, keep `2.x`.
- `.github/workflows/enonic-docgen.yml`: dedupe (the branch already had `3.x`, master's version adds `3.x` between master and 2.x — the merged result is `master, 3.x, 2.x`).

The `2.x` branch is deliberately not touched.

Refs #152 (main "Closes" is on the master PR)