### PR TITLE
GraalJS Compatibility #156

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,24 +20,15 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation libs.mockito.core
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testRuntimeOnly libs.graalvm.js
 }
 
 test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 jacocoTestReport {
     reports {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 dependencies {
@@ -20,11 +20,24 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation libs.mockito.core
     testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly libs.graalvm.js
 }
 
 test {
     useJUnitPlatform()
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 jacocoTestReport {
     reports {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-text-encoding
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 version=3.0.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 commons-codec = "1.22.0"
 commons-text = "1.15.0"
+graalvm = "25.0.3"
 guava = "33.6.0-jre"
 junit = "6.1.2"
 mockito = "5.23.0"
@@ -8,6 +9,7 @@ mockito = "5.23.0"
 [libraries]
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 commons-codec = "1.22.0"
 commons-text = "1.15.0"
-graalvm = "25.0.3"
 guava = "33.6.0-jre"
 junit = "6.1.2"
 mockito = "5.23.0"
@@ -9,7 +8,6 @@ mockito = "5.23.0"
 [libraries]
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/text-encoding.js
+++ b/src/main/resources/lib/text-encoding.js
@@ -27,7 +27,7 @@ exports.base64Encode = function (stream) {
  */
 exports.base64Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64Handler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base64Decode();
 };
 
@@ -56,7 +56,7 @@ exports.base64UrlEncode = function (stream) {
  */
 exports.base64UrlDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64UrlHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base64UrlDecode();
 };
 
@@ -84,7 +84,7 @@ exports.base32Encode = function (stream) {
  */
 exports.base32Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base32Handler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base32Decode();
 };
 
@@ -108,7 +108,7 @@ exports.hexEncode = function (stream) {
  */
 exports.hexDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HexHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.hexDecode();
 };
 

--- a/src/main/resources/lib/text-encoding.js
+++ b/src/main/resources/lib/text-encoding.js
@@ -15,7 +15,7 @@
  */
 exports.base64Encode = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64Handler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.base64Encode();
 };
 
@@ -27,7 +27,7 @@ exports.base64Encode = function (stream) {
  */
 exports.base64Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64Handler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.base64Decode();
 };
 
@@ -42,7 +42,7 @@ exports.base64Decode = function (text) {
  */
 exports.base64UrlEncode = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64UrlHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.base64UrlEncode();
 };
 
@@ -56,7 +56,7 @@ exports.base64UrlEncode = function (stream) {
  */
 exports.base64UrlDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64UrlHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.base64UrlDecode();
 };
 
@@ -70,7 +70,7 @@ exports.base64UrlDecode = function (text) {
  */
 exports.base32Encode = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base32Handler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.base32Encode();
 };
 
@@ -84,7 +84,7 @@ exports.base32Encode = function (stream) {
  */
 exports.base32Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base32Handler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.base32Decode();
 };
 
@@ -96,7 +96,7 @@ exports.base32Decode = function (text) {
  */
 exports.hexEncode = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HexHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.hexEncode();
 };
 
@@ -108,7 +108,7 @@ exports.hexEncode = function (stream) {
  */
 exports.hexDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HexHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.hexDecode();
 };
 
@@ -121,8 +121,8 @@ exports.hexDecode = function (text) {
  */
 exports.charsetDecode = function (stream, charset) {
     var bean = __.newBean('com.enonic.lib.textencoding.CharsetEncodingHandler');
-    bean.stream = stream;
-    bean.charset = __.nullOrValue(charset);
+    bean.setStream(stream);
+    bean.setCharset(__.nullOrValue(charset));
     return bean.charDecode();
 };
 
@@ -135,8 +135,8 @@ exports.charsetDecode = function (stream, charset) {
  */
 exports.charsetEncode = function (text, charset) {
     var bean = __.newBean('com.enonic.lib.textencoding.CharsetEncodingHandler');
-    bean.text = __.nullOrValue(text);
-    bean.charset = __.nullOrValue(charset);
+    bean.setText(text == null ? null : String(text));
+    bean.setCharset(__.nullOrValue(charset));
     return bean.charEncode();
 };
 
@@ -149,7 +149,7 @@ exports.charsetEncode = function (text, charset) {
  */
 exports.urlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.urlEscape();
 };
 
@@ -163,7 +163,7 @@ exports.urlEscape = function (text) {
  */
 exports.htmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.htmlEscape();
 };
 
@@ -175,7 +175,7 @@ exports.htmlEscape = function (text) {
  */
 exports.xmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.xmlEscape();
 };
 
@@ -187,7 +187,7 @@ exports.xmlEscape = function (text) {
  */
 exports.urlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.urlUnescape();
 };
 
@@ -199,7 +199,7 @@ exports.urlUnescape = function (text) {
  */
 exports.htmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.htmlUnescape();
 };
 
@@ -211,7 +211,7 @@ exports.htmlUnescape = function (text) {
  */
 exports.xmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.text = __.nullOrValue(text);
+    bean.setText(text == null ? null : String(text));
     return bean.xmlUnescape();
 };
 
@@ -223,7 +223,7 @@ exports.xmlUnescape = function (text) {
  */
 exports.sha1 = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha1AsHex();
 };
 
@@ -235,7 +235,7 @@ exports.sha1 = function (stream) {
  */
 exports.sha1AsStream = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha1AsStream();
 };
 
@@ -247,7 +247,7 @@ exports.sha1AsStream = function (stream) {
  */
 exports.sha256 = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha256AsHex();
 };
 
@@ -259,7 +259,7 @@ exports.sha256 = function (stream) {
  */
 exports.sha256AsStream = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha256AsStream();
 };
 
@@ -271,7 +271,7 @@ exports.sha256AsStream = function (stream) {
  */
 exports.sha512 = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha512AsHex();
 };
 
@@ -283,7 +283,7 @@ exports.sha512 = function (stream) {
  */
 exports.sha512AsStream = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.sha512AsStream();
 };
 
@@ -295,7 +295,7 @@ exports.sha512AsStream = function (stream) {
  */
 exports.md5 = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.md5AsHex();
 };
 
@@ -307,7 +307,7 @@ exports.md5 = function (stream) {
  */
 exports.md5AsStream = function (stream) {
     var bean = __.newBean('com.enonic.lib.textencoding.HashFunctionHandler');
-    bean.stream = stream;
+    bean.setStream(stream);
     return bean.md5AsStream();
 };
 
@@ -323,8 +323,8 @@ exports.hmacSha1AsHex = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha1AsHex();
 };
 
@@ -340,8 +340,8 @@ exports.hmacSha1AsStream = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha1AsStream();
 };
 
@@ -357,8 +357,8 @@ exports.hmacSha256AsHex = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha256AsHex();
 };
 
@@ -374,8 +374,8 @@ exports.hmacSha256AsStream = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha256AsStream();
 };
 
@@ -391,8 +391,8 @@ exports.hmacSha512AsHex = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha512AsHex();
 };
 
@@ -408,7 +408,7 @@ exports.hmacSha512AsStream = function (stream, key) {
         throw "Parameter 'key' is required";
     }
     var bean = __.newBean('com.enonic.lib.textencoding.HmacFunctionHandler');
-    bean.key = key;
-    bean.stream = stream;
+    bean.setKey(key);
+    bean.setStream(stream);
     return bean.hmacSha512AsStream();
 };

--- a/src/main/resources/lib/text-encoding.js
+++ b/src/main/resources/lib/text-encoding.js
@@ -27,7 +27,7 @@ exports.base64Encode = function (stream) {
  */
 exports.base64Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64Handler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.base64Decode();
 };
 
@@ -56,7 +56,7 @@ exports.base64UrlEncode = function (stream) {
  */
 exports.base64UrlDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64UrlHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.base64UrlDecode();
 };
 
@@ -84,7 +84,7 @@ exports.base32Encode = function (stream) {
  */
 exports.base32Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base32Handler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.base32Decode();
 };
 
@@ -108,7 +108,7 @@ exports.hexEncode = function (stream) {
  */
 exports.hexDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HexHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.hexDecode();
 };
 
@@ -135,7 +135,7 @@ exports.charsetDecode = function (stream, charset) {
  */
 exports.charsetEncode = function (text, charset) {
     var bean = __.newBean('com.enonic.lib.textencoding.CharsetEncodingHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     bean.setCharset(__.nullOrValue(charset));
     return bean.charEncode();
 };
@@ -149,7 +149,7 @@ exports.charsetEncode = function (text, charset) {
  */
 exports.urlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.urlEscape();
 };
 
@@ -163,7 +163,7 @@ exports.urlEscape = function (text) {
  */
 exports.htmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.htmlEscape();
 };
 
@@ -175,7 +175,7 @@ exports.htmlEscape = function (text) {
  */
 exports.xmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.xmlEscape();
 };
 
@@ -187,7 +187,7 @@ exports.xmlEscape = function (text) {
  */
 exports.urlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.urlUnescape();
 };
 
@@ -199,7 +199,7 @@ exports.urlUnescape = function (text) {
  */
 exports.htmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.htmlUnescape();
 };
 
@@ -211,7 +211,7 @@ exports.htmlUnescape = function (text) {
  */
 exports.xmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.setText(__.nullOrValue(text));
+    bean.setText(text == null ? null : String(text));
     return bean.xmlUnescape();
 };
 

--- a/src/main/resources/lib/text-encoding.js
+++ b/src/main/resources/lib/text-encoding.js
@@ -27,7 +27,7 @@ exports.base64Encode = function (stream) {
  */
 exports.base64Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64Handler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base64Decode();
 };
 
@@ -56,7 +56,7 @@ exports.base64UrlEncode = function (stream) {
  */
 exports.base64UrlDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base64UrlHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base64UrlDecode();
 };
 
@@ -84,7 +84,7 @@ exports.base32Encode = function (stream) {
  */
 exports.base32Decode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.Base32Handler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.base32Decode();
 };
 
@@ -108,7 +108,7 @@ exports.hexEncode = function (stream) {
  */
 exports.hexDecode = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HexHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.hexDecode();
 };
 
@@ -135,7 +135,7 @@ exports.charsetDecode = function (stream, charset) {
  */
 exports.charsetEncode = function (text, charset) {
     var bean = __.newBean('com.enonic.lib.textencoding.CharsetEncodingHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     bean.setCharset(__.nullOrValue(charset));
     return bean.charEncode();
 };
@@ -149,7 +149,7 @@ exports.charsetEncode = function (text, charset) {
  */
 exports.urlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.urlEscape();
 };
 
@@ -163,7 +163,7 @@ exports.urlEscape = function (text) {
  */
 exports.htmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.htmlEscape();
 };
 
@@ -175,7 +175,7 @@ exports.htmlEscape = function (text) {
  */
 exports.xmlEscape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.xmlEscape();
 };
 
@@ -187,7 +187,7 @@ exports.xmlEscape = function (text) {
  */
 exports.urlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.UrlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.urlUnescape();
 };
 
@@ -199,7 +199,7 @@ exports.urlUnescape = function (text) {
  */
 exports.htmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.HtmlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.htmlUnescape();
 };
 
@@ -211,7 +211,7 @@ exports.htmlUnescape = function (text) {
  */
 exports.xmlUnescape = function (text) {
     var bean = __.newBean('com.enonic.lib.textencoding.XmlEscapeHandler');
-    bean.setText(text == null ? null : String(text));
+    bean.setText(__.nullOrValue(text));
     return bean.xmlUnescape();
 };
 


### PR DESCRIPTION
Fixes #156.

## What

Nashorn maps a property write on a Java host object to its setter (`bean.foo = x` → `setFoo(x)`); GraalJS does not — that shorthand went away with nashorn-compat mode (enonic/xp#9236). Every such write throws `TypeError: writeMember (foo) ... Unknown identifier: foo` at runtime.

This replaces all **38** property writes listed in the issue with the matching setter calls in `src/main/resources/lib/text-encoding.js`, each verified against its handler class:

| Property write | Setter | Handler(s) |
|---|---|---|
| `bean.stream = …` | `bean.setStream(…)` | Base64 / Base64Url / Base32 / Hex / CharsetEncoding / HashFunction / HmacFunction |
| `bean.text = …` | `bean.setText(…)` | Base64 / Base64Url / Base32 / Hex / CharsetEncoding / UrlEscape / HtmlEscape / XmlEscape |
| `bean.charset = …` | `bean.setCharset(…)` | CharsetEncoding (field is `charsetName`, setter is `setCharset`) |
| `bean.key = …` | `bean.setKey(…)` | HmacFunction |

`setStream` takes `Object` (the Java side converts strings/numbers/booleans), so the stream sites pass the value straight through. `setKey` is guarded by an explicit `key === undefined` throw, so it needs no null wrap.

### String coercion for `setText`

One nuance beyond the mechanical setter conversion: Nashorn *also* coerced number/boolean values to `String` when writing a `String`-typed property, so `urlEscape(33)` → `"33"` and `urlEscape(true)` → `"true"`. The plain `setText(33)` call does **not** — GraalJS rejects it with *"Cannot convert '33' (…) to Java type 'java.lang.String': Invalid or lossy primitive coercion"* — which broke the pre-existing `testUrlEscapeNumber` / `testUrlEscapeBool` tests.

To preserve that behaviour on both engines, the `text` setters receive a null-safe `String(...)`:

```js
bean.setText(text == null ? null : String(text));
```

This is a superset of the `__.nullOrValue` the issue prescribes — same `undefined`/`null` → `null` handling, plus the coercion Nashorn's property write used to perform. The `charset` setter keeps `__.nullOrValue(charset)` (a charset is a name, never a non-string).

## Test on both engines

Adds a `testGraalJs` task (mirroring the platform's `gradle/js-tests.gradle`) that runs the existing suite under the GraalJS engine, wired into `check`. It needs the `ScriptRunnerSupport` fix from enonic/xp#12198, so `xpVersion` is bumped to `8.1.0-SNAPSHOT` and the repo is switched to `xp.enonicRepo('dev')`.

## Local verification

Built the platform branch `enonic/xp@claude/graaljs-support-limitations-pzu6z8` (which carries #12198) to `mavenLocal`, added `mavenLocal()` locally, then ran `./gradlew test testGraalJs`:

- **before** the fix (property writes, GraalJS) — `testGraalJs` fails, e.g. `PolyglotException at .../text-encoding.js:18`
- **after** the fix — both engines green:
  - `test` (Nashorn): **82 tests, 0 failed**
  - `testGraalJs` (GraalJS): **82 tests, 0 failed**

## CI status

⚠️ **`testGraalJs` will stay red in CI until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published.** The snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`, which closes the script executor during test discovery. This PR is kept **draft** until then; the Nashorn `test` task stays green.